### PR TITLE
feat: Create aws glue resources

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_log_group" "glue_job" {
+  name              = "glue-job"
+  retention_in_days = 14
+}

--- a/glue.tf
+++ b/glue.tf
@@ -26,7 +26,7 @@ resource "aws_glue_crawler" "user_database_crawler" {
     Name        = "user-database-crawler"
     Environment = var.env
     Application = "GlueCrawler"
-    Owner       = "Son"
+    Owner       = var.owner_tag
     ManagedBy   = "Terraform"
   }
 }

--- a/glue.tf
+++ b/glue.tf
@@ -1,0 +1,4 @@
+resource "aws_glue_catalog_database" "user" {
+  name        = "user"
+  description = "Database for user data"
+}

--- a/glue.tf
+++ b/glue.tf
@@ -30,3 +30,128 @@ resource "aws_glue_crawler" "user_database_crawler" {
     ManagedBy   = "Terraform"
   }
 }
+
+resource "aws_glue_job" "export_processed_age_data_to_s3" {
+  name              = "export-processed-age-data-to-s3"
+  role_arn          = aws_iam_role.glue.arn
+  description       = "Process user's age data and upload to s3"
+  glue_version      = "4.0"
+  worker_type       = "G.1X"
+  number_of_workers = var.glue_job_export_processed_age_data_to_s3_number_of_workers
+
+  command {
+    script_location = "s3://${aws_s3_bucket.user.bucket}/job/export_processed_age_data_to_s3.py"
+    python_version  = "3"
+  }
+
+  default_arguments = {
+    "--ENV"                              = var.env
+    "--continuous-log-logGroup"          = aws_cloudwatch_log_group.glue_job.name
+    "--enable-continuous-cloudwatch-log" = "true"
+    "--enable-continuous-log-filter"     = "true"
+    "--enable-metrics"                   = "true"
+  }
+
+  tags = {
+    Name        = "export-processed-age-data-to-s3"
+    Environment = var.env
+    Application = "GlueJob"
+    Owner       = var.owner_tag
+    ManagedBy   = "Terraform"
+  }
+}
+
+resource "aws_glue_job" "export_processed_gender_data_to_s3" {
+  name              = "export-processed-gender-data-to-s3"
+  role_arn          = aws_iam_role.glue.arn
+  description       = "Process user's gender data and upload to s3"
+  glue_version      = "4.0"
+  worker_type       = "G.1X"
+  number_of_workers = var.glue_job_export_processed_gender_data_to_s3_number_of_workers
+
+  command {
+    script_location = "s3://${aws_s3_bucket.user.bucket}/job/export_processed_gender_data_to_s3.py"
+    python_version  = "3"
+  }
+
+  default_arguments = {
+    "--ENV"                              = var.env
+    "--continuous-log-logGroup"          = aws_cloudwatch_log_group.glue_job.name
+    "--enable-continuous-cloudwatch-log" = "true"
+    "--enable-continuous-log-filter"     = "true"
+    "--enable-metrics"                   = "true"
+  }
+
+  tags = {
+    Name        = "export-processed-gender-data-to-s3"
+    Environment = var.env
+    Application = "GlueJob"
+    Owner       = var.owner_tag
+    ManagedBy   = "Terraform"
+  }
+}
+
+resource "aws_glue_job" "export_processed_interests_data_to_s3" {
+  name              = "export-processed-interests-data-to-s3"
+  role_arn          = aws_iam_role.glue.arn
+  description       = "Generate interest data from user attribute information and upload to s3"
+  glue_version      = "2.0"
+  worker_type       = "G.2X"
+  number_of_workers = var.glue_job_export_processed_interests_data_to_s3_number_of_workers
+
+  command {
+    script_location = "s3://${aws_s3_bucket.user.bucket}/job/export_processed_interests_data_to_s3.py"
+    python_version  = "3"
+  }
+
+  default_arguments = {
+    "--ENV"                                     = var.env
+    "--continuous-log-logGroup"                 = aws_cloudwatch_log_group.glue_job.name
+    "--enable-continuous-cloudwatch-log"        = "true"
+    "--enable-continuous-log-filter"            = "true"
+    "--enable-metrics"                          = "true"
+    "--write-shuffle-files-to-s3"               = "true"
+    "--write-shuffle-spills-to-s3"              = "true"
+    "--conf spark.shuffle.glue.s3ShuffleBucket" = "s3://${aws_s3_bucket.user.bucket}"
+    "--TempDir"                                 = "s3://${aws_s3_bucket.user.bucket}/shuffle/"
+  }
+
+  tags = {
+    Name        = "export-processed-interests-data-to-s3"
+    Environment = var.env
+    Application = "GlueJob"
+    Owner       = var.owner_tag
+    ManagedBy   = "Terraform"
+  }
+}
+
+resource "aws_glue_job" "notify_workflow_status" {
+  name              = "notify-workflow-status"
+  role_arn          = aws_iam_role.glue.arn
+  description       = "Notify workflow status"
+  glue_version      = "4.0"
+  worker_type       = "G.1X"
+  number_of_workers = var.glue_job_notify_workflow_status_number_of_workers
+
+  command {
+    script_location = "s3://${aws_s3_bucket.user.bucket}/job/notify_workflow_status.py"
+    python_version  = "3"
+  }
+
+  default_arguments = {
+    "--ENV"                              = var.env
+    "--slack_webhook_url"                = var.glue_job_default_arguments_slack_webhook_url
+    "--continuous-log-logGroup"          = aws_cloudwatch_log_group.glue_job.name
+    "--enable-continuous-cloudwatch-log" = "true"
+    "--enable-continuous-log-filter"     = "true"
+    "--enable-metrics"                   = "true"
+  }
+
+  tags = {
+    Name        = "notify-workflow-status"
+    Environment = var.env
+    Application = "GlueJob"
+    Owner       = var.owner_tag
+    ManagedBy   = "Terraform"
+  }
+}

--- a/glue.tf
+++ b/glue.tf
@@ -2,3 +2,31 @@ resource "aws_glue_catalog_database" "user" {
   name        = "user"
   description = "Database for user data"
 }
+
+resource "aws_glue_crawler" "user_database_crawler" {
+  database_name = aws_glue_catalog_database.user.name
+  name          = "user-database-crawler"
+  role          = aws_iam_role.glue.arn
+  description   = "Crawler to update tables in the user database of the glue data catalog"
+  schedule      = var.glue_crawler_user_database_crawler_schedule
+
+  s3_target {
+    path = "s3://${aws_s3_bucket.user.bucket}/age"
+  }
+
+  s3_target {
+    path = "s3://${aws_s3_bucket.user.bucket}/gender"
+  }
+
+  s3_target {
+    path = "s3://${aws_s3_bucket.user.bucket}/interests"
+  }
+
+  tags = {
+    Name        = "user-database-crawler"
+    Environment = var.env
+    Application = "GlueCrawler"
+    Owner       = "Son"
+    ManagedBy   = "Terraform"
+  }
+}

--- a/iam.tf
+++ b/iam.tf
@@ -44,3 +44,80 @@ data "aws_iam_policy_document" "read_s3_user" {
     ]
   }
 }
+
+resource "aws_iam_role" "glue" {
+  name = "glue-service-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "glue.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+data "aws_iam_policy_document" "glue" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      aws_s3_bucket.user.arn,
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.user.arn}/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "glue:*",
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketAcl",
+      "iam:ListRolePolicies",
+      "iam:GetRole",
+      "iam:GetRolePolicy",
+      "cloudwatch:PutMetricData",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+      "logs:PutRetentionPolicy",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "glue" {
+  name        = "${terraform.workspace}-${var.role}-glue-policy"
+  description = "Policies for AWS Glue crawler and job access to resources"
+  policy      = data.aws_iam_policy_document.glue.json
+}
+
+resource "aws_iam_role_policy_attachment" "glue" {
+  role       = aws_iam_role.glue.name
+  policy_arn = aws_iam_policy.glue.arn
+}

--- a/iam.tf
+++ b/iam.tf
@@ -112,8 +112,8 @@ data "aws_iam_policy_document" "glue" {
 }
 
 resource "aws_iam_policy" "glue" {
-  name        = "${terraform.workspace}-${var.role}-glue-policy"
-  description = "Policies for AWS Glue crawler and job access to resources"
+  name        = "glue"
+  description = "Policy for AWS Glue crawler and job access to resources"
   policy      = data.aws_iam_policy_document.glue.json
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -5,7 +5,7 @@ resource "aws_iam_user" "read_s3_user" {
     Name        = "read-s3-user"
     Environment = var.env
     Application = "IAMUser"
-    Owner       = "Son"
+    Owner       = var.owner_tag
     ManagedBy   = "Terraform"
   }
 }

--- a/s3.tf
+++ b/s3.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "user" {
     Name        = "user"
     Environment = var.env
     Application = "S3Bucket"
-    Owner       = "Son"
+    Owner       = var.owner_tag
     ManagedBy   = "Terraform"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -5,3 +5,10 @@ variable "env" {
 variable "region" {
   default = "ap-northeast-1"
 }
+
+#--------------------------------------------------------------
+# Glue Variables
+#--------------------------------------------------------------
+variable "glue_crawler_user_database_crawler_schedule" {
+  default = "cron(30 21 * * ? *)"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -16,3 +16,27 @@ variable "owner_tag" {
 variable "glue_crawler_user_database_crawler_schedule" {
   default = "cron(30 21 * * ? *)"
 }
+
+variable "glue_trigger_export_member_age_gender_segment_to_s3_schedule" {
+  default = "cron(0 22 * * ? *)"
+}
+
+variable "glue_job_export_processed_age_data_to_s3_number_of_workers" {
+  default = 2
+}
+
+variable "glue_job_export_processed_gender_data_to_s3_number_of_workers" {
+  default = 5
+}
+
+variable "glue_job_export_processed_interests_data_to_s3_number_of_workers" {
+  default = 30
+}
+
+variable "glue_job_notify_workflow_status_number_of_workers" {
+  default = 2
+}
+
+variable "glue_job_default_arguments_slack_webhook_url" {
+  default = "https://hooks.slack.com/services/hoge/fuga/bar" # TODO: Replace this
+}

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,10 @@ variable "region" {
   default = "ap-northeast-1"
 }
 
+variable "owner_tag" {
+  default = "Son"
+}
+
 #--------------------------------------------------------------
 # Glue Variables
 #--------------------------------------------------------------


### PR DESCRIPTION
## Describe your changes
Create database in glue data catalog and crawl s3 objects with glue crawler to create table.
Create a glue job resource to retrieve data from the table and execute an ETL job.
- create glue data catalog
- create glue crawler
- create cloudwatch log group
- create glue jobs

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Does it pass status check?
- [x] Have you checked the terraform plan results?
